### PR TITLE
Add collapsible onboarding skip badge with hover effects

### DIFF
--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -33,7 +33,6 @@ import {
   Plug,
   ChevronDown,
   Lock,
-
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -145,9 +144,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   }, []);
 
   const [chatOpen, setChatOpen] = useState(false);
-
-
-
 
   // Tooltip state for disabled Manage Users item (rendered via portal outside sidebar)
   const [manageUsersTooltipVisible, setManageUsersTooltipVisible] =
@@ -693,7 +689,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
               <div className="flex items-center space-x-4">
                 <OnboardingSkipBadge />
                 <div className="flex items-center space-x-3">
-
                   {/* Notification Dropdown */}
                   <div data-tour="notifications" className="relative">
                     <DropdownMenu>
@@ -1159,8 +1154,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           enableDrag={true}
         />
       </div>
-
-
 
       {/* Platform Tour */}
       <PlatformTour

--- a/client/components/layout/DashboardLayout.tsx
+++ b/client/components/layout/DashboardLayout.tsx
@@ -59,6 +59,7 @@ import { DraggableChatSupport } from "@/components/ui/draggable-chat-support";
 import TrialProgressBar from "@/components/ui/trial-progress-bar";
 import TrialBanner from "@/components/ui/trial-banner";
 import TrialBadgeDropdown from "@/components/ui/trial-badge-dropdown";
+import OnboardingSkipBadge from "@/components/layout/OnboardingSkipBadge";
 import { useTour } from "@/contexts/TourContext";
 import PlatformTour from "@/components/tour/PlatformTour";
 
@@ -690,6 +691,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
               {/* Right side - Notification, G2 Reviews, Profile */}
               <div className="flex items-center space-x-4">
+                <OnboardingSkipBadge />
                 <div className="flex items-center space-x-3">
 
                   {/* Notification Dropdown */}

--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -66,14 +66,22 @@ export default function OnboardingSkipBadge({
     navigate(reminder.stepRoute);
   };
 
+  const totalSteps = Math.max(1, reminder.totalSteps ?? 6);
+  const completedSteps = Math.max(0, Math.min(totalSteps, reminder.stepNumber - 1));
+  const progressPercent = Math.max(
+    0,
+    Math.min(100, Math.round((completedSteps / totalSteps) * 100)),
+  );
+  const percentLabel = `${progressPercent}%`;
+
   return (
     <button
       type="button"
       onClick={handleClick}
       className={cn(
-        "group relative flex items-center gap-2 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-3 pl-2 py-1 text-xs font-semibold text-white shadow-[0_10px_25px_rgba(255,106,0,0.2)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
+        "group relative flex min-h-[2.25rem] items-center gap-2 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-3 pl-2 py-1 text-xs font-semibold text-white shadow-[0_8px_22px_rgba(255,106,0,0.18)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
         "before:absolute before:inset-0 before:rounded-full before:bg-white/15 before:opacity-0 before:transition-opacity before:duration-300 group-hover:before:opacity-100",
-        "after:absolute after:inset-0 after:rounded-full after:border after:border-white/30 after:opacity-60 after:animate-[pulse_2s_ease-in-out_infinite]",
+        "after:absolute after:inset-0 after:rounded-full after:border after:border-white/25 after:opacity-60 after:animate-[pulse_2s_ease-in-out_infinite]",
         className,
       )}
       aria-label="Resume onboarding"
@@ -82,15 +90,24 @@ export default function OnboardingSkipBadge({
         <span className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping" aria-hidden />
         <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-white" aria-hidden />
       </span>
-      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-white transition-transform duration-300 group-hover:rotate-3">
-        <Sparkles className="h-3.5 w-3.5" />
+      <span className="relative flex h-7 w-7 items-center justify-center rounded-full bg-white/20 text-[11px] font-semibold text-white transition-all duration-300 group-hover:bg-white/25">
+        <span
+          className="transition-opacity duration-200 group-hover:opacity-0"
+          aria-hidden
+        >
+          {percentLabel}
+        </span>
+        <Sparkles
+          className="absolute h-3.5 w-3.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+          aria-hidden
+        />
       </span>
       <span className="sr-only">Resume onboarding</span>
       <div
         className="flex max-w-0 translate-x-2 flex-col items-start overflow-hidden leading-tight opacity-0 transition-all duration-300 ease-out group-hover:max-w-[220px] group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:max-w-[220px] group-focus-visible:translate-x-0 group-focus-visible:opacity-100"
       >
         <span className="text-[10px] uppercase tracking-wide text-white/75">
-          Resume onboarding
+          Resume onboarding · {percentLabel} complete
         </span>
         <span className="text-sm font-semibold">
           {reminder.stepLabel}

--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -71,20 +71,25 @@ export default function OnboardingSkipBadge({
       type="button"
       onClick={handleClick}
       className={cn(
-        "group relative flex items-center gap-2 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light px-4 py-1.5 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(255,106,0,0.25)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
-        "before:absolute before:inset-0 before:rounded-full before:bg-white/20 before:opacity-0 before:transition-opacity before:duration-300 group-hover:before:opacity-100",
-        "after:absolute after:inset-0 after:rounded-full after:border after:border-white/40 after:opacity-70 after:animate-[pulse_2s_ease-in-out_infinite]",
+        "group relative flex items-center gap-2 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-3 pl-2 py-1 text-xs font-semibold text-white shadow-[0_10px_25px_rgba(255,106,0,0.2)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
+        "before:absolute before:inset-0 before:rounded-full before:bg-white/15 before:opacity-0 before:transition-opacity before:duration-300 group-hover:before:opacity-100",
+        "after:absolute after:inset-0 after:rounded-full after:border after:border-white/30 after:opacity-60 after:animate-[pulse_2s_ease-in-out_infinite]",
         className,
       )}
       aria-label="Resume onboarding"
     >
-      <span className="pointer-events-none absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center">
+      <span className="pointer-events-none absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center">
         <span className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping" aria-hidden />
-        <span className="relative inline-flex h-2 w-2 rounded-full bg-white" aria-hidden />
+        <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-white" aria-hidden />
       </span>
-      <Sparkles className="h-4 w-4" />
-      <div className="flex flex-col items-start leading-tight">
-        <span className="text-[11px] uppercase tracking-wide text-white/80">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-white transition-transform duration-300 group-hover:rotate-3">
+        <Sparkles className="h-3.5 w-3.5" />
+      </span>
+      <span className="sr-only">Resume onboarding</span>
+      <div
+        className="flex max-w-0 translate-x-2 flex-col items-start overflow-hidden leading-tight opacity-0 transition-all duration-300 ease-out group-hover:max-w-[220px] group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:max-w-[220px] group-focus-visible:translate-x-0 group-focus-visible:opacity-100"
+      >
+        <span className="text-[10px] uppercase tracking-wide text-white/75">
           Resume onboarding
         </span>
         <span className="text-sm font-semibold">

--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -18,12 +18,14 @@ export default function OnboardingSkipBadge({
   className,
 }: OnboardingSkipBadgeProps) {
   const navigate = useNavigate();
-  const [reminder, setReminder] = useState<OnboardingSkipReminder | null>(() => {
-    if (typeof window === "undefined") {
-      return null;
-    }
-    return getOnboardingSkipReminder();
-  });
+  const [reminder, setReminder] = useState<OnboardingSkipReminder | null>(
+    () => {
+      if (typeof window === "undefined") {
+        return null;
+      }
+      return getOnboardingSkipReminder();
+    },
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -44,7 +46,10 @@ export default function OnboardingSkipBadge({
       setReminder(getOnboardingSkipReminder());
     };
 
-    window.addEventListener(ONBOARDING_SKIP_EVENT, handleUpdate as EventListener);
+    window.addEventListener(
+      ONBOARDING_SKIP_EVENT,
+      handleUpdate as EventListener,
+    );
     window.addEventListener("storage", handleStorage);
 
     return () => {
@@ -67,7 +72,10 @@ export default function OnboardingSkipBadge({
   };
 
   const totalSteps = Math.max(1, reminder.totalSteps ?? 6);
-  const completedSteps = Math.max(0, Math.min(totalSteps, reminder.stepNumber - 1));
+  const completedSteps = Math.max(
+    0,
+    Math.min(totalSteps, reminder.stepNumber - 1),
+  );
   const progressPercent = Math.max(
     0,
     Math.min(100, Math.round((completedSteps / totalSteps) * 100)),
@@ -87,8 +95,14 @@ export default function OnboardingSkipBadge({
       aria-label={`Resume onboarding, ${percentLabel} complete`}
     >
       <span className="pointer-events-none absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center">
-        <span className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping" aria-hidden />
-        <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-white" aria-hidden />
+        <span
+          className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping"
+          aria-hidden
+        />
+        <span
+          className="relative inline-flex h-1.5 w-1.5 rounded-full bg-white"
+          aria-hidden
+        />
       </span>
       <span className="relative flex h-7 w-7 items-center justify-center rounded-full bg-white/20 text-[11px] font-semibold text-white transition-all duration-300 group-hover:bg-white/25">
         <span
@@ -103,15 +117,11 @@ export default function OnboardingSkipBadge({
         />
       </span>
       <span className="sr-only">Resume onboarding</span>
-      <div
-        className="flex max-w-0 translate-x-2 flex-col items-start overflow-hidden leading-tight opacity-0 transition-all duration-300 ease-out group-hover:max-w-[220px] group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:max-w-[220px] group-focus-visible:translate-x-0 group-focus-visible:opacity-100"
-      >
+      <div className="flex max-w-0 translate-x-2 flex-col items-start overflow-hidden leading-tight opacity-0 transition-all duration-300 ease-out group-hover:max-w-[220px] group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:max-w-[220px] group-focus-visible:translate-x-0 group-focus-visible:opacity-100">
         <span className="text-[10px] uppercase tracking-wide text-white/75">
           Resume onboarding · {percentLabel} complete
         </span>
-        <span className="text-sm font-semibold">
-          {reminder.stepLabel}
-        </span>
+        <span className="text-sm font-semibold">{reminder.stepLabel}</span>
       </div>
     </button>
   );

--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -84,7 +84,7 @@ export default function OnboardingSkipBadge({
         "after:absolute after:inset-0 after:rounded-full after:border after:border-white/25 after:opacity-60 after:animate-[pulse_2s_ease-in-out_infinite]",
         className,
       )}
-      aria-label="Resume onboarding"
+      aria-label={`Resume onboarding, ${percentLabel} complete`}
     >
       <span className="pointer-events-none absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center">
         <span className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping" aria-hidden />

--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  ONBOARDING_SKIP_EVENT,
+  OnboardingSkipReminder,
+  clearOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+  getOnboardingSkipReminder,
+} from "@/lib/onboardingStorage";
+
+interface OnboardingSkipBadgeProps {
+  className?: string;
+}
+
+export default function OnboardingSkipBadge({
+  className,
+}: OnboardingSkipBadgeProps) {
+  const navigate = useNavigate();
+  const [reminder, setReminder] = useState<OnboardingSkipReminder | null>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return getOnboardingSkipReminder();
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleUpdate = (event: Event) => {
+      const customEvent = event as CustomEvent<OnboardingSkipReminder | null>;
+      const detail = customEvent.detail;
+      if (detail) {
+        setReminder(detail);
+      } else {
+        setReminder(getOnboardingSkipReminder());
+      }
+    };
+
+    const handleStorage = () => {
+      setReminder(getOnboardingSkipReminder());
+    };
+
+    window.addEventListener(ONBOARDING_SKIP_EVENT, handleUpdate as EventListener);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener(
+        ONBOARDING_SKIP_EVENT,
+        handleUpdate as EventListener,
+      );
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  if (!reminder) {
+    return null;
+  }
+
+  const handleClick = () => {
+    clearOnboardingSkipReminder();
+    emitOnboardingSkipReminderUpdate(null);
+    navigate(reminder.stepRoute);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "group relative flex items-center gap-2 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light px-4 py-1.5 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(255,106,0,0.25)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
+        "before:absolute before:inset-0 before:rounded-full before:bg-white/20 before:opacity-0 before:transition-opacity before:duration-300 group-hover:before:opacity-100",
+        "after:absolute after:inset-0 after:rounded-full after:border after:border-white/40 after:opacity-70 after:animate-[pulse_2s_ease-in-out_infinite]",
+        className,
+      )}
+      aria-label="Resume onboarding"
+    >
+      <span className="pointer-events-none absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center">
+        <span className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping" aria-hidden />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-white" aria-hidden />
+      </span>
+      <Sparkles className="h-4 w-4" />
+      <div className="flex flex-col items-start leading-tight">
+        <span className="text-[11px] uppercase tracking-wide text-white/80">
+          Resume onboarding
+        </span>
+        <span className="text-sm font-semibold">
+          {reminder.stepLabel}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/client/lib/onboardingStorage.ts
+++ b/client/lib/onboardingStorage.ts
@@ -94,13 +94,15 @@ export interface OnboardingSkipReminder {
 export function saveOnboardingSkipReminder(
   reminder: Omit<OnboardingSkipReminder, "createdAt">,
 ): OnboardingSkipReminder {
-  if (!canUseStorage()) {
-    return { ...reminder, createdAt: Date.now() };
-  }
+  const now = Date.now();
   const value: OnboardingSkipReminder = {
     ...reminder,
-    createdAt: Date.now(),
+    totalSteps: reminder.totalSteps ?? 6,
+    createdAt: now,
   };
+  if (!canUseStorage()) {
+    return value;
+  }
   localStorage.setItem(SKIP_KEY, JSON.stringify(value));
   return value;
 }

--- a/client/lib/onboardingStorage.ts
+++ b/client/lib/onboardingStorage.ts
@@ -87,6 +87,7 @@ export interface OnboardingSkipReminder {
   stepRoute: string;
   stepLabel: string;
   stepNumber: number;
+  totalSteps?: number;
   createdAt: number;
 }
 

--- a/client/lib/onboardingStorage.ts
+++ b/client/lib/onboardingStorage.ts
@@ -46,8 +46,19 @@ export type OnboardingData = {
 };
 
 const KEY = "vais.onboarding";
+const SKIP_KEY = `${KEY}.skip-reminder`;
+export const ONBOARDING_SKIP_EVENT = "vais:onboarding-skip";
+
+function canUseStorage() {
+  return (
+    typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+  );
+}
 
 export function getOnboarding(): OnboardingData {
+  if (!canUseStorage()) {
+    return {};
+  }
   try {
     const raw = localStorage.getItem(KEY);
     return raw ? (JSON.parse(raw) as OnboardingData) : {};
@@ -57,11 +68,70 @@ export function getOnboarding(): OnboardingData {
 }
 
 export function saveOnboarding(patch: Partial<OnboardingData>) {
+  if (!canUseStorage()) {
+    return;
+  }
   const current = getOnboarding();
   const next = { ...current, ...patch };
   localStorage.setItem(KEY, JSON.stringify(next));
 }
 
 export function clearOnboarding() {
+  if (!canUseStorage()) {
+    return;
+  }
   localStorage.removeItem(KEY);
+}
+
+export interface OnboardingSkipReminder {
+  stepRoute: string;
+  stepLabel: string;
+  stepNumber: number;
+  createdAt: number;
+}
+
+export function saveOnboardingSkipReminder(
+  reminder: Omit<OnboardingSkipReminder, "createdAt">,
+) {
+  if (!canUseStorage()) {
+    return { ...reminder, createdAt: Date.now() };
+  }
+  const value: OnboardingSkipReminder = {
+    ...reminder,
+    createdAt: Date.now(),
+  };
+  localStorage.setItem(SKIP_KEY, JSON.stringify(value));
+  return value;
+}
+
+export function getOnboardingSkipReminder(): OnboardingSkipReminder | null {
+  if (!canUseStorage()) {
+    return null;
+  }
+  try {
+    const raw = localStorage.getItem(SKIP_KEY);
+    return raw ? (JSON.parse(raw) as OnboardingSkipReminder) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearOnboardingSkipReminder() {
+  if (!canUseStorage()) {
+    return;
+  }
+  localStorage.removeItem(SKIP_KEY);
+}
+
+export function emitOnboardingSkipReminderUpdate(
+  reminder: OnboardingSkipReminder | null,
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent(ONBOARDING_SKIP_EVENT, {
+      detail: reminder,
+    }),
+  );
 }

--- a/client/lib/onboardingStorage.ts
+++ b/client/lib/onboardingStorage.ts
@@ -92,7 +92,7 @@ export interface OnboardingSkipReminder {
 
 export function saveOnboardingSkipReminder(
   reminder: Omit<OnboardingSkipReminder, "createdAt">,
-) {
+): OnboardingSkipReminder {
   if (!canUseStorage()) {
     return { ...reminder, createdAt: Date.now() };
   }

--- a/client/pages/OnboardingExperience.tsx
+++ b/client/pages/OnboardingExperience.tsx
@@ -10,7 +10,12 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import StepProgress from "@/components/onboarding/StepProgress";
-import { saveOnboarding, getOnboarding } from "@/lib/onboardingStorage";
+import {
+  saveOnboarding,
+  getOnboarding,
+  saveOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+} from "@/lib/onboardingStorage";
 import { useNavigate } from "react-router-dom";
 import { Baby, Gauge, GraduationCap } from "lucide-react";
 import { motion } from "framer-motion";
@@ -32,6 +37,16 @@ export default function OnboardingExperience() {
     if (!value) return;
     saveOnboarding({ experience: value as any });
     navigate("/onboarding/industry");
+  };
+
+  const onSkip = () => {
+    const reminder = saveOnboardingSkipReminder({
+      stepRoute: "/onboarding/experience",
+      stepLabel: "Complete your experience details",
+      stepNumber: 3,
+    });
+    emitOnboardingSkipReminderUpdate(reminder);
+    navigate("/");
   };
 
   return (
@@ -89,7 +104,14 @@ export default function OnboardingExperience() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex justify-end">
+        <CardFooter className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm font-semibold text-valasys-gray-600 transition-colors hover:text-valasys-orange focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange underline-offset-4 hover:underline"
+          >
+            Skip for now
+          </button>
           <Button
             onClick={onNext}
             disabled={!value}

--- a/client/pages/OnboardingExperience.tsx
+++ b/client/pages/OnboardingExperience.tsx
@@ -44,6 +44,7 @@ export default function OnboardingExperience() {
       stepRoute: "/onboarding/experience",
       stepLabel: "Complete your experience details",
       stepNumber: 3,
+      totalSteps: 6,
     });
     emitOnboardingSkipReminderUpdate(reminder);
     navigate("/");


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements a smaller, collapsible onboarding skip badge that shows completion percentage when collapsed and expands with slide animations on hover. The badge provides a visual reminder for users who skipped onboarding steps and allows them to easily resume where they left off.

## Code changes

- **Added `OnboardingSkipBadge` component**: New collapsible badge with hover animations that displays onboarding progress percentage and step information
- **Enhanced onboarding storage**: Extended `onboardingStorage.ts` with skip reminder functionality including save/get/clear operations and event emission
- **Updated `OnboardingExperience`**: Added skip functionality that saves reminder data and navigates to dashboard
- **Integrated badge in `DashboardLayout`**: Positioned the new badge in the header navigation area
- **Implemented responsive design**: Badge shows percentage when small, expands to show full details on hover with smooth slide transitions

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9720052d343e495797a4a4d1fe64f650/zen-world)

👀 [Preview Link](https://9720052d343e495797a4a4d1fe64f650-zen-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9720052d343e495797a4a4d1fe64f650</projectId>-->
<!--<branchName>zen-world</branchName>-->