### PR TITLE
Reduce onboarding badge height to 41px and add skip links

### DIFF
--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -87,24 +87,25 @@ export default function OnboardingSkipBadge({
       type="button"
       onClick={handleClick}
       className={cn(
-        "group relative flex min-h-[2.25rem] items-center gap-2 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-3 pl-2 py-1 text-xs font-semibold text-white shadow-[0_8px_22px_rgba(255,106,0,0.18)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
+        "group relative flex min-h-[1.9rem] items-center gap-1.5 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-2.5 pl-2 py-0.5 text-[11px] font-semibold text-white shadow-[0_8px_22px_rgba(255,106,0,0.18)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
+        "sm:min-h-[2.25rem] sm:gap-2 sm:pr-3 sm:py-1",
         "before:absolute before:inset-0 before:rounded-full before:bg-white/15 before:opacity-0 before:transition-opacity before:duration-300 group-hover:before:opacity-100",
         "after:absolute after:inset-0 after:rounded-full after:border after:border-white/25 after:opacity-60 after:animate-[pulse_2s_ease-in-out_infinite]",
         className,
       )}
       aria-label={`Resume onboarding, ${percentLabel} complete`}
     >
-      <span className="pointer-events-none absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="pointer-events-none absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center sm:h-3.5 sm:w-3.5">
         <span
           className="absolute inline-flex h-full w-full rounded-full bg-white/80 opacity-75 animate-ping"
           aria-hidden
         />
         <span
-          className="relative inline-flex h-1.5 w-1.5 rounded-full bg-white"
+          className="relative inline-flex h-1 w-1 rounded-full bg-white sm:h-1.5 sm:w-1.5"
           aria-hidden
         />
       </span>
-      <span className="relative flex h-7 w-7 items-center justify-center rounded-full bg-white/20 text-[11px] font-semibold text-white transition-all duration-300 group-hover:bg-white/25">
+      <span className="relative flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-[10px] font-semibold text-white transition-all duration-300 group-hover:bg-white/25 sm:h-7 sm:w-7 sm:text-[11px]">
         <span
           className="transition-opacity duration-200 group-hover:opacity-0"
           aria-hidden
@@ -112,16 +113,18 @@ export default function OnboardingSkipBadge({
           {percentLabel}
         </span>
         <Sparkles
-          className="absolute h-3.5 w-3.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+          className="absolute h-3 w-3 opacity-0 transition-opacity duration-200 group-hover:opacity-100 sm:h-3.5 sm:w-3.5"
           aria-hidden
         />
       </span>
       <span className="sr-only">Resume onboarding</span>
-      <div className="flex max-w-0 translate-x-2 flex-col items-start overflow-hidden leading-tight opacity-0 transition-all duration-300 ease-out group-hover:max-w-[220px] group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:max-w-[220px] group-focus-visible:translate-x-0 group-focus-visible:opacity-100">
-        <span className="text-[10px] uppercase tracking-wide text-white/75">
+      <div className="flex max-w-0 translate-x-1.5 flex-col items-start overflow-hidden leading-tight opacity-0 transition-all duration-300 ease-out group-hover:max-w-[220px] group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:max-w-[220px] group-focus-visible:translate-x-0 group-focus-visible:opacity-100 sm:translate-x-2">
+        <span className="text-[9px] uppercase tracking-wide text-white/75 sm:text-[10px]">
           Resume onboarding · {percentLabel} complete
         </span>
-        <span className="text-sm font-semibold">{reminder.stepLabel}</span>
+        <span className="text-xs font-semibold sm:text-sm">
+          {reminder.stepLabel}
+        </span>
       </div>
     </button>
   );

--- a/client/components/layout/OnboardingSkipBadge.tsx
+++ b/client/components/layout/OnboardingSkipBadge.tsx
@@ -87,8 +87,8 @@ export default function OnboardingSkipBadge({
       type="button"
       onClick={handleClick}
       className={cn(
-        "group relative flex min-h-[1.9rem] items-center gap-1.5 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-2.5 pl-2 py-0.5 text-[11px] font-semibold text-white shadow-[0_8px_22px_rgba(255,106,0,0.18)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
-        "sm:min-h-[2.25rem] sm:gap-2 sm:pr-3 sm:py-1",
+        "group relative flex h-[41px] items-center gap-1.5 rounded-full bg-gradient-to-r from-valasys-orange to-valasys-orange-light pr-2.5 pl-2 text-[11px] font-semibold text-white shadow-[0_8px_22px_rgba(255,106,0,0.18)] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange",
+        "sm:h-[41px] sm:gap-2 sm:pr-3",
         "before:absolute before:inset-0 before:rounded-full before:bg-white/15 before:opacity-0 before:transition-opacity before:duration-300 group-hover:before:opacity-100",
         "after:absolute after:inset-0 after:rounded-full after:border after:border-white/25 after:opacity-60 after:animate-[pulse_2s_ease-in-out_infinite]",
         className,
@@ -105,7 +105,7 @@ export default function OnboardingSkipBadge({
           aria-hidden
         />
       </span>
-      <span className="relative flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-[10px] font-semibold text-white transition-all duration-300 group-hover:bg-white/25 sm:h-7 sm:w-7 sm:text-[11px]">
+      <span className="relative flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-[10px] font-semibold text-white transition-all duration-300 group-hover:bg-white/25 sm:h-[26px] sm:w-[26px] sm:text-[11px]">
         <span
           className="transition-opacity duration-200 group-hover:opacity-0"
           aria-hidden

--- a/client/components/onboarding/StepProgress.tsx
+++ b/client/components/onboarding/StepProgress.tsx
@@ -31,7 +31,12 @@ export default function StepProgress({
           Step {current} of {total}
         </div>
       </div>
-      <Progress value={value} className="h-2" />
+      <div className="flex items-center gap-3">
+        <Progress value={value} className="h-2 flex-1" />
+        <span className="text-sm font-medium text-valasys-gray-700 min-w-[3rem] text-right">
+          {value}%
+        </span>
+      </div>
     </div>
   );
 }

--- a/client/pages/OnboardingCategory.tsx
+++ b/client/pages/OnboardingCategory.tsx
@@ -10,7 +10,12 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import StepProgress from "@/components/onboarding/StepProgress";
-import { saveOnboarding, getOnboarding } from "@/lib/onboardingStorage";
+import {
+  saveOnboarding,
+  getOnboarding,
+  saveOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+} from "@/lib/onboardingStorage";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import OnboardingDecor from "@/components/onboarding/Decor";
@@ -81,6 +86,17 @@ export default function OnboardingCategory() {
     navigate("/onboarding/complete");
   };
 
+  const onSkip = () => {
+    const reminder = saveOnboardingSkipReminder({
+      stepRoute: "/onboarding/category",
+      stepLabel: "Choose your product category",
+      stepNumber: 5,
+      totalSteps: 6,
+    });
+    emitOnboardingSkipReminderUpdate(reminder);
+    navigate("/");
+  };
+
   return (
     <div className="relative min-h-screen bg-gradient-to-br from-valasys-gray-50 via-white to-valasys-orange/5 flex items-center justify-center p-6">
       <OnboardingDecor />
@@ -141,7 +157,14 @@ export default function OnboardingCategory() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex justify-end">
+        <CardFooter className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm font-semibold text-valasys-gray-600 transition-colors hover:text-valasys-orange focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange underline-offset-4 hover:underline"
+          >
+            Skip for now
+          </button>
           <Button
             onClick={onNext}
             disabled={!value}

--- a/client/pages/OnboardingIndustry.tsx
+++ b/client/pages/OnboardingIndustry.tsx
@@ -10,7 +10,12 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import StepProgress from "@/components/onboarding/StepProgress";
-import { saveOnboarding, getOnboarding } from "@/lib/onboardingStorage";
+import {
+  saveOnboarding,
+  getOnboarding,
+  saveOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+} from "@/lib/onboardingStorage";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import OnboardingDecor from "@/components/onboarding/Decor";
@@ -55,6 +60,17 @@ export default function OnboardingIndustry() {
     if (!value) return;
     saveOnboarding({ targetIndustry: value });
     navigate("/onboarding/category");
+  };
+
+  const onSkip = () => {
+    const reminder = saveOnboardingSkipReminder({
+      stepRoute: "/onboarding/industry",
+      stepLabel: "Select your target industry",
+      stepNumber: 4,
+      totalSteps: 6,
+    });
+    emitOnboardingSkipReminderUpdate(reminder);
+    navigate("/");
   };
 
   return (
@@ -116,7 +132,14 @@ export default function OnboardingIndustry() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex justify-end">
+        <CardFooter className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm font-semibold text-valasys-gray-600 transition-colors hover:text-valasys-orange focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange underline-offset-4 hover:underline"
+          >
+            Skip for now
+          </button>
           <Button
             onClick={onNext}
             disabled={!value}

--- a/client/pages/OnboardingRole.tsx
+++ b/client/pages/OnboardingRole.tsx
@@ -10,7 +10,12 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import StepProgress from "@/components/onboarding/StepProgress";
-import { saveOnboarding, getOnboarding } from "@/lib/onboardingStorage";
+import {
+  saveOnboarding,
+  getOnboarding,
+  saveOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+} from "@/lib/onboardingStorage";
 import { useNavigate } from "react-router-dom";
 import {
   Brain,
@@ -46,6 +51,17 @@ export default function OnboardingRole() {
     if (!value) return;
     saveOnboarding({ role: value as any });
     navigate("/onboarding/use-case");
+  };
+
+  const onSkip = () => {
+    const reminder = saveOnboardingSkipReminder({
+      stepRoute: "/onboarding/role",
+      stepLabel: "Complete your role selection",
+      stepNumber: 1,
+      totalSteps: 6,
+    });
+    emitOnboardingSkipReminderUpdate(reminder);
+    navigate("/");
   };
 
   return (
@@ -100,7 +116,14 @@ export default function OnboardingRole() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex justify-end">
+        <CardFooter className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm font-semibold text-valasys-gray-600 transition-colors hover:text-valasys-orange focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange underline-offset-4 hover:underline"
+          >
+            Skip for now
+          </button>
           <Button
             onClick={onNext}
             disabled={!value}

--- a/client/pages/OnboardingThankYou.tsx
+++ b/client/pages/OnboardingThankYou.tsx
@@ -8,7 +8,12 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import StepProgress from "@/components/onboarding/StepProgress";
-import { clearOnboarding, getOnboarding } from "@/lib/onboardingStorage";
+import {
+  clearOnboarding,
+  clearOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+  getOnboarding,
+} from "@/lib/onboardingStorage";
 import { useNavigate } from "react-router-dom";
 import OnboardingDecor from "@/components/onboarding/Decor";
 import ConfettiCanvas from "@/components/onboarding/ConfettiCanvas";
@@ -20,6 +25,8 @@ export default function OnboardingThankYou() {
 
   const continueToApp = () => {
     clearOnboarding();
+    clearOnboardingSkipReminder();
+    emitOnboardingSkipReminderUpdate(null);
     navigate("/");
   };
 

--- a/client/pages/OnboardingUseCase.tsx
+++ b/client/pages/OnboardingUseCase.tsx
@@ -10,7 +10,12 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import StepProgress from "@/components/onboarding/StepProgress";
-import { saveOnboarding, getOnboarding } from "@/lib/onboardingStorage";
+import {
+  saveOnboarding,
+  getOnboarding,
+  saveOnboardingSkipReminder,
+  emitOnboardingSkipReminderUpdate,
+} from "@/lib/onboardingStorage";
 import { useNavigate } from "react-router-dom";
 import { ListChecks, Rocket, Database } from "lucide-react";
 import { motion } from "framer-motion";
@@ -32,6 +37,17 @@ export default function OnboardingUseCase() {
     if (!value) return;
     saveOnboarding({ useCase: value as any });
     navigate("/onboarding/experience");
+  };
+
+  const onSkip = () => {
+    const reminder = saveOnboardingSkipReminder({
+      stepRoute: "/onboarding/use-case",
+      stepLabel: "Tell us your primary goal",
+      stepNumber: 2,
+      totalSteps: 6,
+    });
+    emitOnboardingSkipReminderUpdate(reminder);
+    navigate("/");
   };
 
   return (
@@ -89,7 +105,14 @@ export default function OnboardingUseCase() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex justify-end">
+        <CardFooter className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm font-semibold text-valasys-gray-600 transition-colors hover:text-valasys-orange focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-valasys-orange underline-offset-4 hover:underline"
+          >
+            Skip for now
+          </button>
           <Button
             onClick={onNext}
             disabled={!value}


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several onboarding UX improvements:
- Reduce the resume onboarding badge height to exactly 41px for better visual consistency
- Add percentage display alongside the progress bar for clearer completion tracking
- Implement skip functionality across all onboarding screens for improved user flow

## Code changes

### OnboardingSkipBadge Component
- **Height standardization**: Changed from `min-h-[2.25rem]` to fixed `h-[41px]` with responsive variants
- **Responsive sizing**: Added smaller dimensions for mobile (`h-6 w-6`, `text-[10px]`) with larger desktop sizes (`sm:h-[26px] sm:w-[26px]`)
- **Spacing optimization**: Reduced gaps and padding for compact mobile display while maintaining desktop usability

### StepProgress Component
- **Progress visualization**: Added percentage display next to progress bar with proper alignment and styling
- **Layout enhancement**: Wrapped progress bar and percentage in flex container with appropriate spacing

### Onboarding Pages (Role, UseCase, Industry, Category)
- **Skip functionality**: Added "Skip for now" buttons to all onboarding steps
- **Navigation consistency**: Implemented skip handlers that save reminder state and redirect to home
- **Footer layout**: Updated CardFooter to use responsive flex layout (column on mobile, row on desktop)

### OnboardingThankYou Page
- **Cleanup logic**: Added proper cleanup of skip reminders when onboarding completes successfully

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/91aa477ecff344d9b9daaba2b8092485/quantum-space)

👀 [Preview Link](https://91aa477ecff344d9b9daaba2b8092485-quantum-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>91aa477ecff344d9b9daaba2b8092485</projectId>-->
<!--<branchName>quantum-space</branchName>-->